### PR TITLE
fix implodeElements case when received string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -163,6 +163,10 @@ function sign(methodName, params, key) {
 
 function implodeElements(obj) {
   let result = ''
+  if (typeof obj === 'string') {
+    result += obj
+    return result
+  }
   const keys = Object.keys(obj)
   keys.sort()
 


### PR DESCRIPTION
Привет. Функция implodeElements сейчас неправильно работает когда значение obj это строка
Например, `obj === '12345678@gmail.com'`
result `12mail.com345678@g`